### PR TITLE
Release 1.5.0

### DIFF
--- a/LICENCE.txt
+++ b/LICENCE.txt
@@ -4,7 +4,7 @@ follows:
 
 ----- begin license block -----
 
-Copyright 2014-2016 Deux Huit Huit Inc.
+Copyright 2014-2018 Deux Huit Huit Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,28 +1,27 @@
 # Ajax Checkbox #
 
-Version: 1.4.x
+Makes checkbox fields editable inline in the table publish view. Value is saved right away.
 
-Makes the checkbox field editable inline in the table publish view.
-Value is saved right away.
 
-### COMPATIBILITY ###
+## Compatibility
 
 Besides Symphony's default checkbox field **Ajax Checkbox** plays nicely together with the following extensions:
 
-1. [Multilingual Checkbox][1]
-2. [Publish Button][2]
+1. [Multilingual Checkbox][2]
+2. [Publish Button][3]
 
 The following extensions are currently not supported:
 
-1. [Unpublishedfilter][3]
-2. [Unique Checkbox Field][4]
+1. [Unpublishedfilter][4]
+2. [Unique Checkbox Field][5]
 
 
-### REQUIREMENTS ###
+## Requirements
 
-- Symphony CMS version 2.4 and up (as of the day of the last release of this extension)
+- [Symphony CMS][1] version 2.4 and up (as of the day of the last release of this extension)
 
-### INSTALLATION ##
+
+## Installation
 
 - `git clone` / download and unpack the tarball file
 - Put into the extension directory
@@ -34,12 +33,14 @@ See <http://getsymphony.com/learn/tasks/view/install-an-extension/>
 
 Come say hi! -> <https://deuxhuithuit.com/>
 
-### HOW TO USE ###
+
+## How to use
 
 - Just install and enjoy
 
 
-[1]: https://github.com/DeuxHuitHuit/multilingual_checkbox_field
-[2]: https://github.com/pixelninja/publishbutton
-[3]: https://github.com/symphonists/unpublishedfilter
-[4]: https://github.com/symphonists/uniquecheckboxfield
+[1]: http://www.getsymphony.com/
+[2]: https://github.com/DeuxHuitHuit/multilingual_checkbox_field
+[3]: https://github.com/pixelninja/publishbutton
+[4]: https://github.com/symphonists/unpublishedfilter
+[5]: https://github.com/symphonists/uniquecheckboxfield

--- a/README.md
+++ b/README.md
@@ -5,16 +5,24 @@ Version: 1.4.x
 Makes the checkbox field editable inline in the table publish view.
 Value is saved right away.
 
-### KNOWN LIMITATIONS
+### COMPATIBILITY ###
 
-- It is not compatible with the `unpublishedfilter` extension.
-- You cannot use a checkbox as the last column
+Besides Symphony's default checkbox field **Ajax Checkbox** plays nicely together with the following extensions:
+
+1. [Multilingual Checkbox][1]
+2. [Publish Button][2]
+
+The following extensions are currently not supported:
+
+1. [Unpublishedfilter][3]
+2. [Unique Checkbox Field][4]
+
 
 ### REQUIREMENTS ###
 
 - Symphony CMS version 2.4 and up (as of the day of the last release of this extension)
 
-### INSTALLATION ###
+### INSTALLATION ##
 
 - `git clone` / download and unpack the tarball file
 - Put into the extension directory
@@ -29,3 +37,9 @@ Come say hi! -> <https://deuxhuithuit.com/>
 ### HOW TO USE ###
 
 - Just install and enjoy
+
+
+[1]: https://github.com/DeuxHuitHuit/multilingual_checkbox_field
+[2]: https://github.com/pixelninja/publishbutton
+[3]: https://github.com/symphonists/unpublishedfilter
+[4]: https://github.com/symphonists/uniquecheckboxfield

--- a/assets/publish.ajax_checkbox.css
+++ b/assets/publish.ajax_checkbox.css
@@ -6,22 +6,25 @@
  */
 
 table.selectable td.field-checkbox input.ajax-checkbox,
-table.selectable td.field-multilingual_checkbox input.ajax-checkbox {
+table.selectable td.field-multilingual_checkbox input.ajax-checkbox,
+table.selectable td.field-publishbutton input.ajax-checkbox {
 	display: inline-block;
 	float: none;
 	vertical-align: middle;
-	margin-top: -1px;
+	margin-top: -.1rem;
 }
 
 table.selectable td.field-checkbox,
-table.selectable td.field-multilingual_checkbox {
+table.selectable td.field-multilingual_checkbox,
+table.selectable td.field-publishbutton {
 	position: relative;
 }
 
 table.selectable td.field-checkbox div.ajax-checkbox,
-table.selectable td.field-multilingual_checkbox div.ajax-checkbox {
-	width: 16px;
-	height: 11px;
+table.selectable td.field-multilingual_checkbox div.ajax-checkbox,
+table.selectable td.field-publishbutton div.ajax-checkbox {
+	width: 1.6rem;
+	height: 1.1rem;
 	background: transparent url(ajax-loader.gif) no-repeat 0px 0px;
 	display: none;
 }

--- a/assets/publish.ajax_checkbox.js
+++ b/assets/publish.ajax_checkbox.js
@@ -99,7 +99,7 @@
 	};
 	
 	var init = function () {
-		$('#contents table td').filter('.field-checkbox, .field-multilingual_checkbox').each(initOne);
+		$('#contents table td').filter('.field-checkbox, .field-multilingual_checkbox, .field-publishbutton').each(initOne);
 	};
 	
 	$(init);

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extension id="ajax_checkbox" status="released" xmlns="http://getsymphony.com/schemas/extension/1.0">
 	<name>Ajax Checkbox</name>
-	<description>
-		Makes the checkbox field editable inline in the table publish view.
-		Value is saved right away.
-	</description>
+	<description>Makes checkbox fields editable inline in the table publish view. Value is saved right away.</description>
 	<repo type="github">https://github.com/DeuxHuitHuit/ajax_checkbox</repo>
 	<url type="discuss">http://www.getsymphony.com/discuss/thread/111985/</url>
 	<url type="issues">https://github.com/DeuxHuitHuit/ajax_checkbox/issues</url>

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -23,6 +23,10 @@
 		<!-- None -->
 	</dependencies>
 	<releases>
+		<release version="1.5.0" date="2018-06-14" min="2.4.0" max="2.x.x">
+			- Added support for [Publish Button](https://github.com/pixelninja/publishbutton) extension
+			- Extended compatibility notes in the readme
+		</release>
 		<release version="1.4.1" date="2016-08-08" min="2.3.4" max="2.x.x">
 			- Supported on PHP 7
 			- Fixed database update


### PR DESCRIPTION
- Added Support for the „Publish Button“-extension
- Switched `px` for `rem` in the CSS
- Extended compatibility notes in the readme
- Improved headline hierarchy in the readme
- Removed version note in the readme
- Removed the note about the „last column“-problem in the readme (which obviously was
fixed in version 1.3.0)
- Prepared meta for 1.5.0 release (Setting Symphony 2.4 as minimum like
it was already stated in the readme)
